### PR TITLE
Update bukkit location URL

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,3 @@
 For more information:
 
-http://dev.bukkit.org/server-mods/enchanter/
+https://dev.bukkit.org/projects/enchanter/


### PR DESCRIPTION
The old URL throws a 404 error. This will correct the link to the dev.bukkit.org resource.